### PR TITLE
no-danger-with-children spread variable guard

### DIFF
--- a/src/rules/no-danger-with-children.coffee
+++ b/src/rules/no-danger-with-children.coffee
@@ -39,8 +39,8 @@ module.exports =
           variable = findSpreadVariable prop.argument.name
           if (
             val =
-              variable.defs[0]?.node.init ?
-              (isDeclarationAssignment(variable?.defs[0]?.node.parent) and
+              variable?.defs?[0]?.node.init ?
+              (isDeclarationAssignment(variable?.defs?[0]?.node.parent) and
                 variable.defs[0].node.parent.right)
           )
             return no if seenProps.indexOf(prop.argument.name) > -1
@@ -59,7 +59,7 @@ module.exports =
         if attribute.type is 'JSXSpreadAttribute'
           variable = findSpreadVariable attribute.argument.name
           return findObjectProp variable.defs[0].node.init, propName, [] if (
-            variable.defs[0]?.node.init
+            variable?.defs?[0]?.node.init
           )
           return findObjectProp(
             variable.defs[0].node.parent.right

--- a/src/tests/rules/no-danger-with-children.coffee
+++ b/src/tests/rules/no-danger-with-children.coffee
@@ -73,6 +73,27 @@ ruleTester.run 'no-danger-with-children', rule,
       props = {...props, scratch: {mode: 'edit'}}
       component = shallow(<TaskEditableTitle {...props} />)
     '''
+  ,
+    # #35
+    '''
+      import React from 'react'
+
+      export default class ReactView
+        props: label: 'test'
+
+        render: ->
+          <div>
+            <span {@props...}>test</span>
+          </div>
+    '''
+    '''
+      import React from 'react'
+
+      render = ->
+        <div>
+          <span {foo...}>test</span>
+        </div>
+    '''
   ]
   invalid: [
     code: '''


### PR DESCRIPTION
Fixes #35 

In this PR:
- `no-danger-with-children` was crashing on a missing guard for spread props where no definition was found for the spread variable