### PR TITLE
Don't flag static properties in shorthand-this

### DIFF
--- a/src/rules/shorthand-this.coffee
+++ b/src/rules/shorthand-this.coffee
@@ -18,6 +18,10 @@ isObjectShorthand = (node) ->
   {parent} = node
   parent.parent.type is 'Property' and parent.parent.shorthand
 
+isStaticProperty = (node) ->
+  {parent} = node
+  parent?.type is 'ClassProperty' and node is parent.staticClassName
+
 #------------------------------------------------------------------------------
 # Rule Definition
 #------------------------------------------------------------------------------
@@ -53,7 +57,11 @@ module.exports =
     ThisExpression: (node) ->
       isShorthand = !!node.shorthand
       isStandalone = not isProperty node
-      return if isThisParam(node) or isObjectShorthand node
+      return if (
+        isThisParam(node) or
+        isObjectShorthand(node) or
+        isStaticProperty node
+      )
       if isShorthand
         if forbidShorthand
           context.report {

--- a/src/tests/rules/shorthand-this.coffee
+++ b/src/tests/rules/shorthand-this.coffee
@@ -71,6 +71,31 @@ ruleTester.run 'shorthand-this', rule,
         b: (@c) ->
     '''
     options: ['never']
+  ,
+    # should never flag static method/property @
+    code: '''
+      class A
+        @b: (c) ->
+        @d = 1
+        @e: 2
+    '''
+    options: ['never']
+  ,
+    code: '''
+      class A
+        @b: (c) ->
+        @d = 1
+        @e: 2
+    '''
+    options: ['always']
+  ,
+    code: '''
+      class A
+        @b: (c) ->
+        @d = 1
+        @e: 2
+    '''
+    options: ['allow', {forbidStandalone: yes}]
   ]
   invalid: [
     code: '@'


### PR DESCRIPTION
In this PR:
- never flag static class properties' `@` in `shorthand-this` rule