### PR TITLE
Dynamically monkeypatch code path analysis

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -8,7 +8,10 @@ babylonToEspree = require 'babel-eslint/babylon-to-espree'
 babelTraverse = require('babel-traverse').default
 babylonTokenTypes = require('babylon').tokTypes
 {flatten, assign: extend, repeat} = require 'lodash'
-patchCodePathAnalysis = require './patch-code-path-analysis'
+{
+  patchCodePathAnalysis
+  PATCH_CODE_PATH_ANALYSIS_PROGRAM_NODE_KEY
+} = require './patch-code-path-analysis'
 patchImportExportMap = require './patch-import-export-map'
 # patchReact = require './patch-react'
 analyzeScope = require './analyze-scope'
@@ -108,7 +111,7 @@ getEspreeTokenType = (token) ->
 getTokenValue = (token) ->
   [type, value, {range}] = token
   if type is 'INTERPOLATION_START'
-    return if range[1] - range[0] is 1 then '{' else '#{'
+    return (if range[1] - range[0] is 1 then '{' else '#{')
   return '}' if type is 'INTERPOLATION_END'
   return repeat '"', range[1] - range[0] if type in [
     'STRING_START'
@@ -243,6 +246,8 @@ exports.getParser = getParser = (getAst) -> (code, opts) ->
     ast.program?.range[1] = ast.program.end
   # eslint-scope will fail eg on ImportDeclaration's unless treated as module
   ast.sourceType = 'module'
+  # hack to enable "dynamic monkeypatching" of code path analysis
+  ast[PATCH_CODE_PATH_ANALYSIS_PROGRAM_NODE_KEY] = yes
   # dump espreeAst: ast
   {
     ast

--- a/src/patch-code-path-analysis.coffee
+++ b/src/patch-code-path-analysis.coffee
@@ -1,19 +1,46 @@
 CodePathAnalyzer = require './code-path-analysis/code-path-analyzer'
 
-module.exports = ->
-  try
-    ESLintCodePathAnalyzer = require(
-      'eslint/lib/code-path-analysis/code-path-analyzer'
-    )
-  catch
+PROGRAM_NODE_KEY = '__coffee__'
+
+monkeypatchMethod = (ESLintCodePathAnalyzer, isCurrentFileCoffeescript, key) ->
+  original = ESLintCodePathAnalyzer::[key]
+  dynamicallyDelegatingMonkeypatch = (...args) ->
+    if isCurrentFileCoffeescript.current
+      # eslint-disable-next-line coffee/no-invalid-this
+      CodePathAnalyzer::[key].apply @, args
+    else
+      # eslint-disable-next-line coffee/no-invalid-this
+      original.apply @, args
+  if key is 'enterNode'
+    ESLintCodePathAnalyzer::[key] = (...args) ->
+      [node] = args
+      isCurrentFileCoffeescript.current = !!node[PROGRAM_NODE_KEY] if (
+        node?.type is 'Program'
+      )
+      dynamicallyDelegatingMonkeypatch.apply @, args
+  else
+    ESLintCodePathAnalyzer::[key] = dynamicallyDelegatingMonkeypatch
+
+module.exports =
+  patchCodePathAnalysis: ->
     try
       ESLintCodePathAnalyzer = require(
-        'eslint/lib/linter/code-path-analysis/code-path-analyzer'
+        'eslint/lib/code-path-analysis/code-path-analyzer'
       )
     catch
-      throw new ReferenceError "Couldn't resolve eslint CodePathAnalyzer"
-  return if ESLintCodePathAnalyzer.__monkeypatched
-  # ESLintCodePathAnalyzer:: = CodePathAnalyzer::
-  for key in ['enterNode', 'leaveNode', 'onLooped']
-    ESLintCodePathAnalyzer::[key] = CodePathAnalyzer::[key]
-  ESLintCodePathAnalyzer.__monkeypatched = yes
+      try
+        ESLintCodePathAnalyzer = require(
+          'eslint/lib/linter/code-path-analysis/code-path-analyzer'
+        )
+      catch
+        throw new ReferenceError "Couldn't resolve eslint CodePathAnalyzer"
+    return if ESLintCodePathAnalyzer.__monkeypatched
+    # ESLintCodePathAnalyzer:: = CodePathAnalyzer::
+    isCurrentFileCoffeescript = current: no
+    monkeypatchMethod(
+      ESLintCodePathAnalyzer
+      isCurrentFileCoffeescript
+      key
+    ) for key in ['enterNode', 'leaveNode', 'onLooped']
+    ESLintCodePathAnalyzer.__monkeypatched = yes
+  PATCH_CODE_PATH_ANALYSIS_PROGRAM_NODE_KEY: PROGRAM_NODE_KEY


### PR DESCRIPTION
Per #48 / https://github.com/eslint/eslint/issues/14078, the monkeypatching of ESLint's code path analysis can crash linting of non-Coffeescript files

So this attempts to restrict the monkeypatching to only be "in effect" when linting Coffeescript files via `eslint-plugin-coffee`