### PR TITLE
Expose disable-incompatible config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,16 @@ npm install --save-dev coffeescript@^2.5.0 eslint@^6.0.0 eslint-plugin-coffee
 
 ## Usage
 
-Add `eslint-plugin-coffee` to the `parser` field and `coffee` to the plugins section of your `.eslintrc` configuration file:
+Add `eslint-plugin-coffee` to the `parser` field and `coffee` to the plugins section of your `.eslintrc` configuration file,
+and disable ESLint rules that aren't compatible with CoffeeScript:
 
 ```
 {
   "parser": "eslint-plugin-coffee",
-  "plugins": ["coffee"]
+  "plugins": ["coffee"],
+  "extends": [
+    "plugin/coffee:disable-incompatible"
+  ]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-coffee",
-  "version": "0.1.14",
+  "version": "0.1.15-dev.1",
   "description": "ESLint plugin for Coffeescript",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1113,7 +1113,7 @@ airbnbConfig = merge(
 module.exports = {
   rules: mapValues('module') rules
   configs:
-    basic:
+    'disable-incompatible':
       plugins: ['coffee']
       parser: 'eslint-plugin-coffee'
       rules: {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1113,6 +1113,13 @@ airbnbConfig = merge(
 module.exports = {
   rules: mapValues('module') rules
   configs:
+    basic:
+      plugins: ['coffee']
+      parser: 'eslint-plugin-coffee'
+      rules: {
+        ...turnOff(dontApply)
+        ...turnOff(yet)
+      }
     all:
       plugins: ['coffee']
       parser: 'eslint-plugin-coffee'


### PR DESCRIPTION
Per #51, we should try and "enforce" that incompatible/non-applicable ESLint rules are disabled by anyone using this plugin

So this exposes a `disable-incompatible` config and updates the README to include turning on that config as part of the basic setup instructions