### PR TITLE
Don't flag first of two for variables as unused

### DIFF
--- a/src/rules/no-unused-vars.coffee
+++ b/src/rules/no-unused-vars.coffee
@@ -158,6 +158,19 @@ module.exports =
 
       node.type is 'ClassExpression'
 
+    isFirstOfTwoForVariables = (variable) ->
+      definition = variable.defs[0]
+
+      return no unless definition
+
+      {node} = definition
+      {parent} = node
+      return no unless parent?
+
+      parent.type is 'For' and
+        ((parent.style is 'in' and node is parent.name and parent.index?) or
+          (parent.style is 'of' and node is parent.index and parent.name?))
+
     ###*
     # Determines if a variable has a sibling rest property
     # @param {Variable} variable - eslint-scope variable object.
@@ -499,6 +512,7 @@ module.exports =
             not isUsedVariable(variable) and
             not isExported(variable) and
             not isClassExpression(variable) and
+            not isFirstOfTwoForVariables(variable) and
             not hasRestSpreadSibling variable
           )
             unusedVars.push variable

--- a/src/tests/rules/no-unused-vars.coffee
+++ b/src/tests/rules/no-unused-vars.coffee
@@ -661,6 +661,14 @@ ruleTester.run 'no-unused-vars', rule,
       export class A
         [f()]: 2
     '''
+    '''
+      for v, i in a by f()
+        forCompile.push i
+    '''
+    '''
+      for k, v of a
+        x(v)
+    '''
   ]
   invalid: [
     code: 'foox = -> foox()', errors: [assignedError 'foox']
@@ -1268,4 +1276,11 @@ ruleTester.run 'no-unused-vars', rule,
     code: 'do (_a) ->'
     options: [args: 'all', caughtErrorsIgnorePattern: '^_']
     errors: [message: "'_a' is defined but never used."]
+  ,
+    # flag single unused for variable
+    code: '''
+      for k of a
+        x()
+    '''
+    errors: [message: "'k' is assigned a value but never used."]
   ]


### PR DESCRIPTION
In this PR:
- don't flag first of two `for` variables as unused in `no-unused-vars`

Fixes #18