### PR TITLE
Make react-all config turn on all compatible rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-coffee",
-  "version": "0.1.15-dev.2",
+  "version": "0.1.15-dev.3",
   "description": "ESLint plugin for Coffeescript",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1152,6 +1152,7 @@ module.exports = {
       parser: 'eslint-plugin-coffee'
       extends: ['plugin:react/all']
       rules: {
+        ...turnOn(filter((rule) -> /^react\//.test rule) usable)
         ...configureAsError(pickBy(plugin: 'react') rules)
         ...turnOff(dontApply)
         ...turnOff(yet)


### PR DESCRIPTION
In this PR:
- make `react-all` config turn on all compatible non-overridden `eslint-plugin-react` rules. This looks like it was an oversight since the `import-all` config already behaved this way

Per https://github.com/helixbass/eslint-plugin-coffee/issues/51#issuecomment-781002134