### PR TITLE
Don't flag loop statements in no-constant-condition

### DIFF
--- a/src/rules/no-constant-condition.coffee
+++ b/src/rules/no-constant-condition.coffee
@@ -176,7 +176,10 @@ module.exports =
     # @returns {void}
     # @private
     ###
-    checkLoop = (node) -> if checkLoops then trackConstantConditionLoop node
+    checkLoop = (node) ->
+      return if node.type is 'WhileStatement' and node.loop
+      return unless checkLoops
+      trackConstantConditionLoop node
 
     #--------------------------------------------------------------------------
     # Public

--- a/src/tests/rules/no-constant-condition.coffee
+++ b/src/tests/rules/no-constant-condition.coffee
@@ -54,6 +54,8 @@ ruleTester.run 'no-constant-condition', rule,
   ,
     code: 'loop then ;', options: [checkLoops: no]
   ,
+    code: 'loop then ;'
+  ,
     '''
       foo = ->
         while true
@@ -120,8 +122,6 @@ ruleTester.run 'no-constant-condition', rule,
   ,
     code: 'while (true) then ;'
     errors: [messageId: 'unexpected', type: 'Literal']
-  ,
-    code: 'loop then ;', errors: [messageId: 'unexpected', type: 'Literal']
   ,
     # #5228 , typeof conditions
     code: 'if (typeof x) then ;'


### PR DESCRIPTION
In this PR:
- don't flag `loop` statements in `coffee/no-constant-condition` (since presumably you intentionally want a constant-condition loop if you're using `loop`)

Fixes #53 