### PR TITLE
Avoid jsx-no-bind crash

### DIFF
--- a/src/rules/jsx-no-bind.coffee
+++ b/src/rules/jsx-no-bind.coffee
@@ -67,6 +67,7 @@ module.exports =
         func: new Set()
 
     getNodeViolationType = (node) ->
+      return null unless node?
       nodeType = node.type
 
       return 'bindCall' if (

--- a/src/tests/rules/jsx-no-bind.coffee
+++ b/src/tests/rules/jsx-no-bind.coffee
@@ -191,10 +191,12 @@ ruleTester.run 'jsx-no-bind', rule,
   ,
     code: '<div onClick={-> alert("1337")}></div>'
     options: [ignoreDOMComponents: yes]
+  ,
     # ,
     #   code: '<div foo={::this.onChange} />'
     #   options: [ignoreDOMComponents: yes]
     #   parser: 'babel-eslint'
+    code: '<a href={if user? then path}>My Posts</a>'
   ]
 
   invalid: [


### PR DESCRIPTION
In this PR:
- avoid `coffee/jsx-no-bind` crashing on conditional expressions with no `else` per https://github.com/helixbass/eslint-plugin-coffee/issues/51#issuecomment-790981168