### PR TITLE
Fix no-undef JSX fragment issue

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -13,6 +13,7 @@ babylonTokenTypes = require('babylon').tokTypes
   PATCH_CODE_PATH_ANALYSIS_PROGRAM_NODE_KEY
 } = require './patch-code-path-analysis'
 patchImportExportMap = require './patch-import-export-map'
+patchBabelTypes = require './patch-babel-types'
 # patchReact = require './patch-react'
 analyzeScope = require './analyze-scope'
 CodePathAnalyzer = require './code-path-analysis/code-path-analyzer'
@@ -218,6 +219,7 @@ tokensForESLint = ({tokens}) ->
 exports.getParser = getParser = (getAst) -> (code, opts) ->
   patchCodePathAnalysis() unless opts.eslintCodePathAnalyzer
   patchImportExportMap()
+  patchBabelTypes()
   # patchReact()
   # ESLint replaces shebang #! with //, but leading // could be part of a heregex
   if /// ^ // ///.test code

--- a/src/patch-babel-types.coffee
+++ b/src/patch-babel-types.coffee
@@ -1,0 +1,40 @@
+require 'babel-types'
+
+{
+  default: defineType
+  assertNodeType
+  assertValueType
+  chain
+  assertEach
+  VISITOR_KEYS
+} = require 'babel-types/lib/definitions'
+
+module.exports = ->
+  return if VISITOR_KEYS.JSXFragment
+
+  defineType 'JSXFragment',
+    builder: ['openingFragment', 'closingFragment', 'children']
+    visitor: ['openingFragment', 'children', 'closingFragment']
+    aliases: ['JSX', 'Immutable', 'Expression']
+    fields:
+      openingFragment:
+        validate: assertNodeType 'JSXOpeningFragment'
+      closingFragment:
+        validate: assertNodeType 'JSXClosingFragment'
+      children:
+        validate: chain(
+          assertValueType 'array'
+          assertEach(
+            assertNodeType(
+              'JSXText'
+              'JSXExpressionContainer'
+              'JSXSpreadChild'
+              'JSXElement'
+              'JSXFragment'
+            )
+          )
+        )
+
+  defineType 'JSXOpeningFragment', aliases: ['JSX', 'Immutable']
+
+  defineType 'JSXClosingFragment', aliases: ['JSX', 'Immutable']

--- a/src/rules/jsx-one-expression-per-line.coffee
+++ b/src/rules/jsx-one-expression-per-line.coffee
@@ -77,8 +77,7 @@ module.exports =
         countNewLinesAfterContent = 0
 
         if child.type in ['Literal', 'JSXText']
-          # TODO: this is only necessary b/c JSXFragments aren't currently getting transformed Babel -> espree
-          raw = child.extra?.raw ? child.raw
+          {raw} = child
           return if /^\s*$/.test raw
 
           countNewLinesBeforeContent = (raw.match(/^ *\n/g) or []).length


### PR DESCRIPTION
In this PR:
- fix issue reported in https://github.com/helixbass/eslint-plugin-coffee/issues/51#issuecomment-791036315 where `no-undef` was false-triggering inside a JSX fragment