### PR TITLE
Upgrade eslint-plugin-react; override jsx-no-target-blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Then use the `prettier-run-as-rule` config exposed by this plugin:
 | :heavy_check_mark: |          | [`coffee/jsx-no-comment-textnodes`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md) | Prevent comments from being inserted as text nodes |
 | :heavy_check_mark: |          | [`react/jsx-no-duplicate-props`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md) | Prevent duplicate props in JSX |
 |                    |          | [`react/jsx-no-literals`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md) | Prevent usage of unwrapped JSX strings |
-| :heavy_check_mark: |          | [`react/jsx-no-target-blank`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Prevent usage of unsafe `target='_blank'` |
+| :heavy_check_mark: |          | [`coffee/jsx-no-target-blank`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) | Prevent usage of unsafe `target='_blank'` |
 | :heavy_check_mark: |          | [`react/jsx-no-undef`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md) | Disallow undeclared variables in JSX |
 |                    |          | [`coffee/jsx-one-expression-per-line`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-one-expression-per-line.md) | Limit to one expression per line in JSX |
 |                    | :wrench: | [`react/jsx-curly-brace-presence`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md) | Enforce curly braces or disallow unnecessary curly braces in JSX |

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.19.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.17.0",
+    "eslint-plugin-react": "7.23.2",
     "eslint-plugin-react-native": "^3.8.0",
     "eslint-scope": "~3.7.3",
     "eslint-utils": "^1.4.3",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -143,7 +143,6 @@ usable = [
   'react/jsx-child-element-spacing'
   'react/jsx-closing-tag-location'
   'react/jsx-pascal-case'
-  'react/jsx-no-target-blank'
   'react/jsx-curly-spacing'
   'react/jsx-equals-spacing'
   'react/jsx-filename-extension'
@@ -782,6 +781,9 @@ rules =
       plugin: 'react'
       prettier: yes
       airbnb: ['error', {maximum: 1, when: 'multiline'}]
+    'jsx-no-target-blank':
+      plugin: 'react'
+      airbnb: ['error', {enforceDynamicLinks: 'always'}]
     'no-else-return':
       'airbnb-base': ['error', {allowElseIf: no}]
     'operator-linebreak':

--- a/src/rules/jsx-no-target-blank.coffee
+++ b/src/rules/jsx-no-target-blank.coffee
@@ -1,0 +1,222 @@
+###*
+# @fileoverview Forbid target='_blank' attribute
+# @author Kevin Miller
+###
+
+'use strict'
+
+docsUrl = require 'eslint-plugin-react/lib/util/docsUrl'
+linkComponentsUtil = require 'eslint-plugin-react/lib/util/linkComponents'
+
+# ------------------------------------------------------------------------------
+# Rule Definition
+# ------------------------------------------------------------------------------
+
+findLastIndex = (arr, condition) ->
+  i = arr.length - 1
+  while i >= 0
+    return i if condition arr[i]
+    i -= 1
+
+  -1
+
+attributeValuePossiblyBlank = (attribute) ->
+  return no unless attribute?.value
+  {value} = attribute
+  return (
+    typeof value.value is 'string' and value.value.toLowerCase() is '_blank'
+  ) if value.type is 'Literal'
+  if value.type is 'JSXExpressionContainer'
+    expr = value.expression
+    return (
+      typeof expr.value is 'string' and expr.value.toLowerCase() is '_blank'
+    ) if expr.type is 'Literal'
+    if expr.type is 'ConditionalExpression'
+      return yes if (
+        expr.alternate?.type is 'Literal' and
+        expr.alternate.value and
+        expr.alternate.value.toLowerCase() is '_blank'
+      )
+      return yes if (
+        expr.consequent.type is 'Literal' and
+        expr.consequent.value and
+        expr.consequent.value.toLowerCase() is '_blank'
+      )
+  no
+
+hasExternalLink = (
+  node
+  linkAttribute
+  warnOnSpreadAttributes
+  spreadAttributeIndex
+) ->
+  linkIndex = findLastIndex node.attributes, (attr) ->
+    attr.name?.name is linkAttribute
+  foundExternalLink =
+    linkIndex isnt -1 and
+    ((attr) ->
+      attr.value.type is 'Literal' and /^(?:\w+:|\/\/)/.test attr.value.value
+    ) node.attributes[linkIndex]
+  foundExternalLink or
+    (warnOnSpreadAttributes and linkIndex < spreadAttributeIndex)
+
+hasDynamicLink = (node, linkAttribute) ->
+  dynamicLinkIndex = findLastIndex node.attributes, (attr) ->
+    attr.name?.name is linkAttribute and
+    attr.value and
+    attr.value.type is 'JSXExpressionContainer'
+  return yes unless dynamicLinkIndex is -1
+  undefined
+
+getStringFromValue = (value) ->
+  if value
+    return value.value if value.type is 'Literal'
+    if value.type is 'JSXExpressionContainer'
+      return value.expression.quasis[0].value.cooked if (
+        value.expression.type is 'TemplateLiteral'
+      )
+      return value.expression?.value
+  null
+
+hasSecureRel = (
+  node
+  allowReferrer
+  warnOnSpreadAttributes
+  spreadAttributeIndex
+) ->
+  relIndex = findLastIndex node.attributes, (attr) ->
+    attr.type is 'JSXAttribute' and attr.name.name is 'rel'
+  return no if (
+    relIndex is -1 or
+    (warnOnSpreadAttributes and relIndex < spreadAttributeIndex)
+  )
+
+  relAttribute = node.attributes[relIndex]
+  value = getStringFromValue relAttribute.value
+  tags = value and typeof value is 'string' and value.toLowerCase().split ' '
+  noreferrer = tags and tags.indexOf('noreferrer') >= 0
+  return yes if noreferrer
+  allowReferrer and tags and tags.indexOf('noopener') >= 0
+
+module.exports =
+  meta:
+    fixable: 'code'
+    docs:
+      description:
+        'Forbid `target="_blank"` attribute without `rel="noreferrer"`'
+      category: 'Best Practices'
+      recommended: yes
+      url: docsUrl 'jsx-no-target-blank'
+
+    messages:
+      noTargetBlank:
+        'Using target="_blank" without rel="noreferrer" ' +
+        'is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
+
+    schema: [
+      type: 'object'
+      properties:
+        allowReferrer:
+          type: 'boolean'
+        enforceDynamicLinks:
+          enum: ['always', 'never']
+        warnOnSpreadAttributes:
+          type: 'boolean'
+      additionalProperties: no
+    ]
+
+  create: (context) ->
+    configuration = context.options[0] or {}
+    allowReferrer = configuration.allowReferrer or no
+    warnOnSpreadAttributes = configuration.warnOnSpreadAttributes or no
+    enforceDynamicLinks = configuration.enforceDynamicLinks or 'always'
+    components = linkComponentsUtil.getLinkComponents context
+
+    JSXOpeningElement: (node) ->
+      return unless components.has node.name.name
+
+      targetIndex = findLastIndex node.attributes, (attr) ->
+        attr.name?.name is 'target'
+      spreadAttributeIndex = findLastIndex node.attributes, (attr) ->
+        attr.type is 'JSXSpreadAttribute'
+
+      unless attributeValuePossiblyBlank node.attributes[targetIndex]
+        hasSpread = spreadAttributeIndex >= 0
+
+        if warnOnSpreadAttributes and hasSpread
+          # continue to check below
+        else
+          return if (
+            (hasSpread and targetIndex < spreadAttributeIndex) or
+            not hasSpread or
+            not warnOnSpreadAttributes
+          )
+
+      linkAttribute = components.get node.name.name
+      hasDangerousLink =
+        hasExternalLink(
+          node
+          linkAttribute
+          warnOnSpreadAttributes
+          spreadAttributeIndex
+        ) or
+        (enforceDynamicLinks is 'always' and hasDynamicLink node, linkAttribute)
+      if (
+        hasDangerousLink and
+        not hasSecureRel(
+          node
+          allowReferrer
+          warnOnSpreadAttributes
+          spreadAttributeIndex
+        )
+      )
+        context.report {
+          node
+          messageId: 'noTargetBlank'
+          fix: (fixer) ->
+            # eslint 5 uses `node.attributes`; eslint 6+ uses `node.parent.attributes`
+            nodeWithAttrs = if node.parent.attributes then node.parent else node
+            # eslint 5 does not provide a `name` property on JSXSpreadElements
+            relAttribute = nodeWithAttrs.attributes.find (attr) ->
+              attr.name?.name is 'rel'
+
+            return null if (
+              targetIndex < spreadAttributeIndex or
+              (spreadAttributeIndex >= 0 and not relAttribute)
+            )
+
+            return fixer.insertTextAfter(
+              nodeWithAttrs.attributes.slice(-1)[0]
+              ' rel="noreferrer"'
+            ) unless relAttribute
+
+            return fixer.insertTextAfter relAttribute, '="noreferrer"' unless (
+              relAttribute.value
+            )
+
+            if relAttribute.value.type is 'Literal'
+              parts =
+                relAttribute.value.value.split('noreferrer').filter Boolean
+              return fixer.replaceText(
+                relAttribute.value
+                "\"#{parts.concat('noreferrer').join ' '}\""
+              )
+
+            if relAttribute.value.type is 'JSXExpressionContainer'
+              if relAttribute.value.expression.type is 'Literal'
+                if typeof relAttribute.value.expression.value is 'string'
+                  parts =
+                    relAttribute.value.expression.value
+                    .split('noreferrer')
+                    .filter Boolean
+                  return fixer.replaceText(
+                    relAttribute.value.expression
+                    "\"#{parts.concat('noreferrer').join ' '}\""
+                  )
+
+                # for undefined, boolean, number, symbol, bigint, and null
+                return fixer.replaceText relAttribute.value, '"noreferrer"'
+
+            null
+        }
+      undefined

--- a/src/tests/rules/button-has-type.coffee
+++ b/src/tests/rules/button-has-type.coffee
@@ -62,11 +62,14 @@ ruleTester.run 'button-has-type', rule,
     errors: [message: '"foo" is an invalid value for button type attribute']
   ,
     code: '<button type={foo}/>'
-    errors: [message: '`foo` is an invalid value for button type attribute']
+    errors: [
+      message:
+        'The button type attribute must be specified by a static string or a trivial ternary expression'
+    ]
   ,
     code: '<button type="reset"/>'
     options: [reset: no]
-    errors: [message: '"reset" is a forbidden value for button type attribute']
+    errors: [message: '"reset" is an invalid value for button type attribute']
   ,
     code: 'React.createElement("button")'
     errors: [message: 'Missing an explicit type attribute for button']
@@ -79,7 +82,7 @@ ruleTester.run 'button-has-type', rule,
   ,
     code: 'React.createElement("button", {type: "reset"})'
     options: [reset: no]
-    errors: [message: '"reset" is a forbidden value for button type attribute']
+    errors: [message: '"reset" is an invalid value for button type attribute']
   ,
     code: 'Foo.createElement("button")'
     errors: [message: 'Missing an explicit type attribute for button']

--- a/src/tests/rules/forbid-component-props.coffee
+++ b/src/tests/rules/forbid-component-props.coffee
@@ -15,8 +15,8 @@ path = require 'path'
 # Tests
 # -----------------------------------------------------------------------------
 
-CLASSNAME_ERROR_MESSAGE = 'Prop `className` is forbidden on Components'
-STYLE_ERROR_MESSAGE = 'Prop `style` is forbidden on Components'
+CLASSNAME_ERROR_MESSAGE = 'Prop "className" is forbidden on Components'
+STYLE_ERROR_MESSAGE = 'Prop "style" is forbidden on Components'
 
 ruleTester = new RuleTester parser: path.join __dirname, '../../..'
 ruleTester.run 'forbid-component-props', rule,

--- a/src/tests/rules/forbid-dom-props.coffee
+++ b/src/tests/rules/forbid-dom-props.coffee
@@ -17,7 +17,7 @@ require 'babel-eslint'
 # Tests
 # -----------------------------------------------------------------------------
 
-ID_ERROR_MESSAGE = 'Prop `id` is forbidden on DOM Nodes'
+ID_ERROR_MESSAGE = 'Prop "id" is forbidden on DOM Nodes'
 
 ruleTester = new RuleTester parser: path.join __dirname, '../../..'
 ruleTester.run 'forbid-element-props', rule,

--- a/src/tests/rules/jsx-curly-brace-presence.coffee
+++ b/src/tests/rules/jsx-curly-brace-presence.coffee
@@ -159,12 +159,6 @@ ruleTester.run 'jsx-curly-brace-presence', rule,
     code: '<MyComponent>{"<Foo />"}</MyComponent>'
     options: ['never']
   ,
-    code: '<MyComponent prop={"{ style: true }"}>bar</MyComponent>'
-    options: ['never']
-  ,
-    code: '<MyComponent prop={"< style: true >"}>foo</MyComponent>'
-    options: ['never']
-  ,
     code: '<MyComponent prop={"Hello \\u1026 world"}>bar</MyComponent>'
     options: ['never']
   ,
@@ -382,4 +376,14 @@ ruleTester.run 'jsx-curly-brace-presence', rule,
     ].join '\n'
     errors: [{message: missingCurlyMessage}, {message: missingCurlyMessage}]
     options: ['always']
+  ,
+    code: '<MyComponent prop={"{ style: true }"}>bar</MyComponent>'
+    output: '<MyComponent prop="{ style: true }">bar</MyComponent>'
+    errors: [message: unnecessaryCurlyMessage]
+    options: ['never']
+  ,
+    code: '<MyComponent prop={"< style: true >"}>foo</MyComponent>'
+    output: '<MyComponent prop="< style: true >">foo</MyComponent>'
+    errors: [message: unnecessaryCurlyMessage]
+    options: ['never']
   ]

--- a/src/tests/rules/jsx-no-literals.coffee
+++ b/src/tests/rules/jsx-no-literals.coffee
@@ -108,7 +108,7 @@ ruleTester.run 'jsx-no-literals', rule,
         </Foo>
       '''
     # parser: 'babel-eslint'
-    options: [noStrings: yes]
+    options: [noStrings: yes, ignoreProps: yes]
   ,
     code: '''
         <Foo bar="test">
@@ -116,21 +116,21 @@ ruleTester.run 'jsx-no-literals', rule,
         </Foo>
       '''
     # parser: 'babel-eslint'
-    options: [noStrings: yes]
+    options: [noStrings: yes, ignoreProps: yes]
   ,
     code: '''
         <Foo bar="test">
           {intl.formatText(message)}
         </Foo>
       '''
-    options: [noStrings: yes]
+    options: [noStrings: yes, ignoreProps: yes]
   ,
     code: '''
         <Foo bar="test">
           {translate('my.translate.key')}
         </Foo>
       '''
-    options: [noStrings: yes]
+    options: [noStrings: yes, ignoreProps: yes]
   ,
     code: '<Foo bar={true} />'
     options: [noStrings: yes]
@@ -172,7 +172,7 @@ ruleTester.run 'jsx-no-literals', rule,
       '''
     # parser: 'babel-eslint'
     errors: [
-      message: 'Missing JSX expression container around literal string: “test”'
+      message: 'Missing JSX expression container around literal string: "test"'
     ]
   ,
     code: '''
@@ -182,7 +182,7 @@ ruleTester.run 'jsx-no-literals', rule,
       '''
     # parser: 'babel-eslint'
     errors: [
-      message: 'Missing JSX expression container around literal string: “test”'
+      message: 'Missing JSX expression container around literal string: "test"'
     ]
   ,
     code: '''
@@ -193,7 +193,7 @@ ruleTester.run 'jsx-no-literals', rule,
       '''
     # parser: 'babel-eslint'
     errors: [
-      message: 'Missing JSX expression container around literal string: “test”'
+      message: 'Missing JSX expression container around literal string: "test"'
     ]
   ,
     code: '''
@@ -204,7 +204,7 @@ ruleTester.run 'jsx-no-literals', rule,
       '''
     # parser: 'babel-eslint'
     errors: [
-      message: 'Missing JSX expression container around literal string: “test”'
+      message: 'Missing JSX expression container around literal string: "test"'
     ]
   ,
     code: '''
@@ -216,7 +216,7 @@ ruleTester.run 'jsx-no-literals', rule,
       '''
     # parser: 'babel-eslint'
     errors: [
-      message: 'Missing JSX expression container around literal string: “hello”'
+      message: 'Missing JSX expression container around literal string: "hello"'
     ]
   ,
     code: '''
@@ -231,7 +231,7 @@ ruleTester.run 'jsx-no-literals', rule,
     # parser: 'babel-eslint'
     errors: [
       message:
-        'Missing JSX expression container around literal string: “asdjfl”'
+        'Missing JSX expression container around literal string: "asdjfl"'
     ]
   ,
     code: '''
@@ -248,7 +248,7 @@ ruleTester.run 'jsx-no-literals', rule,
     # parser: 'babel-eslint'
     errors: [
       message:
-        'Missing JSX expression container around literal string: “asdjfl\n        test\n        foo”'
+        'Missing JSX expression container around literal string: "asdjfl\n        test\n        foo"'
     ]
   ,
     code: '''
@@ -264,7 +264,7 @@ ruleTester.run 'jsx-no-literals', rule,
       '''
     # parser: 'babel-eslint'
     errors: [
-      message: 'Missing JSX expression container around literal string: “test”'
+      message: 'Missing JSX expression container around literal string: "test"'
     ]
   ,
     code: '''
@@ -273,24 +273,24 @@ ruleTester.run 'jsx-no-literals', rule,
         </Foo>
       '''
     # parser: 'babel-eslint'
-    options: [noStrings: yes]
-    errors: [message: "Strings not allowed in JSX files: “'Test'”"]
+    options: [noStrings: yes, ignoreProps: yes]
+    errors: [message: 'Strings not allowed in JSX files: "\'Test\'"']
   ,
     code: '''
         <Foo bar="test">
           {'Test'}
         </Foo>
       '''
-    options: [noStrings: yes]
-    errors: [message: "Strings not allowed in JSX files: “'Test'”"]
+    options: [noStrings: yes, ignoreProps: yes]
+    errors: [message: 'Strings not allowed in JSX files: "\'Test\'"']
   ,
     code: '''
         <Foo bar="test">
           {'Test' + name}
         </Foo>
       '''
-    options: [noStrings: yes]
-    errors: [message: "Strings not allowed in JSX files: “'Test'”"]
+    options: [noStrings: yes, ignoreProps: yes]
+    errors: [message: 'Strings not allowed in JSX files: "\'Test\'"']
   ,
     code: '''
         <Foo bar="test">
@@ -298,16 +298,16 @@ ruleTester.run 'jsx-no-literals', rule,
         </Foo>
       '''
     # parser: 'babel-eslint'
-    options: [noStrings: yes]
-    errors: [message: 'Strings not allowed in JSX files: “Test”']
+    options: [noStrings: yes, ignoreProps: yes]
+    errors: [message: 'Strings not allowed in JSX files: "Test"']
   ,
     code: '''
         <Foo bar="test">
           Test
         </Foo>
       '''
-    options: [noStrings: yes]
-    errors: [message: 'Strings not allowed in JSX files: “Test”']
+    options: [noStrings: yes, ignoreProps: yes]
+    errors: [message: 'Strings not allowed in JSX files: "Test"']
   ,
     code: '''
         <Foo>
@@ -315,41 +315,41 @@ ruleTester.run 'jsx-no-literals', rule,
         </Foo>
       '''
     options: [noStrings: yes]
-    errors: [message: 'Strings not allowed in JSX files: “"Test"”']
+    errors: [message: 'Strings not allowed in JSX files: ""Test""']
   ,
     code: '<Foo bar={"Test"} />'
     options: [noStrings: yes]
-    errors: [message: 'Strings not allowed in JSX files: “"Test"”']
+    errors: [message: 'Strings not allowed in JSX files: ""Test""']
   ,
     code: '<Foo bar={"#{baz}"} />'
     options: [noStrings: yes]
-    errors: [message: 'Strings not allowed in JSX files: “"#{baz}"”']
+    errors: [message: 'Strings not allowed in JSX files: ""#{baz}""']
   ,
     code: '<Foo bar={"Test #{baz}"} />'
     options: [noStrings: yes]
-    errors: [message: 'Strings not allowed in JSX files: “"Test #{baz}"”']
+    errors: [message: 'Strings not allowed in JSX files: ""Test #{baz}""']
   ,
     code: '<Foo bar={"foo" + \'bar\'} />'
     options: [noStrings: yes]
     errors: [
-      message: 'Strings not allowed in JSX files: “"foo"”'
+      message: 'Strings not allowed in JSX files: ""foo""'
     ,
-      message: "Strings not allowed in JSX files: “'bar'”"
+      message: 'Strings not allowed in JSX files: "\'bar\'"'
     ]
   ,
     code: '<Foo bar={"foo" + "bar"} />'
     options: [noStrings: yes]
     errors: [
-      message: 'Strings not allowed in JSX files: “"foo"”'
+      message: 'Strings not allowed in JSX files: ""foo""'
     ,
-      message: 'Strings not allowed in JSX files: “"bar"”'
+      message: 'Strings not allowed in JSX files: ""bar""'
     ]
   ,
     code: '<Foo bar={\'foo\' + "bar"} />'
     options: [noStrings: yes]
     errors: [
-      message: "Strings not allowed in JSX files: “'foo'”"
+      message: 'Strings not allowed in JSX files: "\'foo\'"'
     ,
-      message: 'Strings not allowed in JSX files: “"bar"”'
+      message: 'Strings not allowed in JSX files: ""bar""'
     ]
   ]

--- a/src/tests/rules/jsx-no-target-blank.coffee
+++ b/src/tests/rules/jsx-no-target-blank.coffee
@@ -19,8 +19,8 @@ path = require 'path'
 ruleTester = new RuleTester parser: path.join __dirname, '../../..'
 defaultErrors = [
   message:
-    'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
-    ' see https://mathiasbynens.github.io/rel-noopener'
+    'Using target="_blank" without rel="noreferrer" is a security risk:' +
+    ' see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
 ]
 
 ruleTester.run 'jsx-no-target-blank', rule,

--- a/src/tests/rules/jsx-no-target-blank.coffee
+++ b/src/tests/rules/jsx-no-target-blank.coffee
@@ -8,7 +8,7 @@
 # Requirements
 # ------------------------------------------------------------------------------
 
-rule = require 'eslint-plugin-react/lib/rules/jsx-no-target-blank'
+rule = require '../../rules/jsx-no-target-blank'
 {RuleTester} = require 'eslint'
 path = require 'path'
 
@@ -32,6 +32,10 @@ ruleTester.run 'jsx-no-target-blank', rule,
     # ,
     #   code: '<a target />'
     code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>'
+  ,
+    code: '<a href="foobar" target="_blank" rel="noreferrer"></a>'
+  ,
+    code: '<a href="foobar" target="_blank" rel={"noreferrer"}></a>'
   ,
     code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>'
   ,
@@ -57,6 +61,9 @@ ruleTester.run 'jsx-no-target-blank', rule,
   ]
   invalid: [
     code: '<a target="_blank" href="http://example.com"></a>'
+    errors: defaultErrors
+  ,
+    code: '<a target={if b then "_blank"} href="http://example.com"></a>'
     errors: defaultErrors
   ,
     code: '<a target="_blank" rel="" href="http://example.com"></a>'

--- a/src/tests/rules/jsx-props-no-multi-spaces.coffee
+++ b/src/tests/rules/jsx-props-no-multi-spaces.coffee
@@ -42,35 +42,35 @@ ruleTester.run 'jsx-props-no-multi-spaces', rule,
   invalid: [
     code: ['<App  foo />'].join '\n'
     output: ['<App foo />'].join '\n'
-    errors: [message: 'Expected only one space between "App" and "foo"']
+    errors: [message: 'Expected only one space between “App” and “foo”']
   ,
     code: ['<App foo="with  spaces   "   bar />'].join '\n'
     output: ['<App foo="with  spaces   " bar />'].join '\n'
-    errors: [message: 'Expected only one space between "foo" and "bar"']
+    errors: [message: 'Expected only one space between “foo” and “bar”']
   ,
     code: ['<App foo  bar />'].join '\n'
     output: ['<App foo bar />'].join '\n'
-    errors: [message: 'Expected only one space between "foo" and "bar"']
+    errors: [message: 'Expected only one space between “foo” and “bar”']
   ,
     code: ['<App  foo   bar />'].join '\n'
     output: ['<App foo bar />'].join '\n'
     errors: [
-      message: 'Expected only one space between "App" and "foo"'
+      message: 'Expected only one space between “App” and “foo”'
     ,
-      message: 'Expected only one space between "foo" and "bar"'
+      message: 'Expected only one space between “foo” and “bar”'
     ]
   ,
     code: ['<App foo  {...test}  bar />'].join '\n'
     output: ['<App foo {...test} bar />'].join '\n'
     errors: [
-      message: 'Expected only one space between "foo" and "test"'
+      message: 'Expected only one space between “foo” and “test”'
     ,
-      message: 'Expected only one space between "test" and "bar"'
+      message: 'Expected only one space between “test” and “bar”'
     ]
   ,
     code: '<Foo.Bar  baz="quux" />'
     output: '<Foo.Bar baz="quux" />'
-    errors: [message: 'Expected only one space between "Foo.Bar" and "baz"']
+    errors: [message: 'Expected only one space between “Foo.Bar” and “baz”']
   ,
     code:
       '<Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh  xyzzy="thud" />'
@@ -78,6 +78,6 @@ ruleTester.run 'jsx-props-no-multi-spaces', rule,
       '<Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh xyzzy="thud" />'
     errors: [
       message:
-        'Expected only one space between "Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh" and "xyzzy"'
+        'Expected only one space between “Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh” and “xyzzy”'
     ]
   ]

--- a/src/tests/rules/jsx-sort-props.coffee
+++ b/src/tests/rules/jsx-sort-props.coffee
@@ -86,7 +86,7 @@ ruleTester.run 'jsx-sort-props', rule,
   ,
     code: '<App c="a" {...this.props} a="c" b="b" />'
   ,
-    code: '<App a A />'
+    code: '<App A a />'
   ,
     # Ignoring case
     code: '<App a A />', options: ignoreCaseArgs
@@ -154,10 +154,6 @@ ruleTester.run 'jsx-sort-props', rule,
     code: '<App c {...this.props} b a />'
     errors: [expectedError]
     output: '<App c {...this.props} a b />'
-  ,
-    code: '<App A a />'
-    errors: [expectedError]
-    output: '<App a A />'
   ,
     code: '<App B a />'
     options: ignoreCaseArgs

--- a/src/tests/rules/no-find-dom-node.coffee
+++ b/src/tests/rules/no-find-dom-node.coffee
@@ -16,6 +16,9 @@ path = require 'path'
 # Tests
 # ------------------------------------------------------------------------------
 
+message =
+  'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
+
 ruleTester = new RuleTester parser: path.join __dirname, '../../..'
 ruleTester.run 'no-find-dom-node', rule,
   valid: [
@@ -59,7 +62,7 @@ ruleTester.run 'no-find-dom-node', rule,
           return <div>Hello</div>
       })
     '''
-    errors: [message: 'Do not use findDOMNode']
+    errors: [{message}]
   ,
     code: '''
       Hello = createReactClass({
@@ -69,7 +72,7 @@ ruleTester.run 'no-find-dom-node', rule,
           return <div>Hello</div>
       })
     '''
-    errors: [message: 'Do not use findDOMNode']
+    errors: [{message}]
   ,
     code: '''
       class Hello extends Component
@@ -78,7 +81,7 @@ ruleTester.run 'no-find-dom-node', rule,
         render: ->
           return <div>Hello</div>
     '''
-    errors: [message: 'Do not use findDOMNode']
+    errors: [{message}]
   ,
     code: '''
       class Hello extends Component
@@ -87,5 +90,5 @@ ruleTester.run 'no-find-dom-node', rule,
         render: ->
           return <div>Hello</div>
     '''
-    errors: [message: 'Do not use findDOMNode']
+    errors: [{message}]
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,13 +177,16 @@ array-find@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
   integrity sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=
 
-array-includes@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
-  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
+array-includes@^3.0.3, array-includes@^3.1.2, array-includes@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a"
+  integrity sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==
   dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.7.0"
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.5"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -204,6 +207,16 @@ array.prototype.flat@^1.2.1:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.15.0"
+    function-bind "^1.1.1"
+
+array.prototype.flatmap@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9"
+  integrity sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
 
 asn1.js@^4.0.0:
@@ -435,6 +448,14 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
+
+call-bind@^1.0.0, call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 caller-callsite@^2.0.0:
   version "2.0.0"
@@ -744,7 +765,7 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -871,21 +892,27 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.12.0, es-abstract@^1.15.0, es-abstract@^1.7.0:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.3.tgz#52490d978f96ff9f89ec15b5cf244304a5bca161"
-  integrity sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==
+es-abstract@^1.15.0, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0.tgz#ab80b359eecb7ede4c298000390bc5ac3ec7b5a4"
+  integrity sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
   dependencies:
+    call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.1"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-inspect "^1.7.0"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.2"
+    is-string "^1.0.5"
+    object-inspect "^1.9.0"
     object-keys "^1.1.1"
-    string.prototype.trimleft "^2.1.0"
-    string.prototype.trimright "^2.1.0"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.0"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -980,11 +1007,6 @@ eslint-plugin-coffee@^0.1.12:
     jsx-ast-utils "^2.0.1"
     lodash "^4.17.10"
 
-eslint-plugin-eslint-plugin@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz#a7a00f15a886957d855feacaafee264f039e62d5"
-  integrity sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg==
-
 eslint-plugin-import@^2.19.0:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz#5654e10b7839d064dd0d46cd1b88ec2133a11448"
@@ -1038,21 +1060,23 @@ eslint-plugin-react-native@^3.8.0:
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 
-eslint-plugin-react@^7.17.0:
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz#a31b3e134b76046abe3cd278e7482bd35a1d12d7"
-  integrity sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==
+eslint-plugin-react@7.23.2, eslint-plugin-react@^7.17.0:
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.23.2.tgz#2d2291b0f95c03728b55869f01102290e792d494"
+  integrity sha512-AfjgFQB+nYszudkxRkTFu0UR1zEQig0ArVMPloKhxwlwkzaw/fBiH0QWcBBhZONlXqQC51+nfqFrkn4EzHcGBw==
   dependencies:
-    array-includes "^3.0.3"
+    array-includes "^3.1.3"
+    array.prototype.flatmap "^1.2.4"
     doctrine "^2.1.0"
-    eslint-plugin-eslint-plugin "^2.1.0"
     has "^1.0.3"
-    jsx-ast-utils "^2.2.3"
-    object.entries "^1.1.0"
-    object.fromentries "^2.0.1"
-    object.values "^1.1.0"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.0.4"
+    object.entries "^1.1.3"
+    object.fromentries "^2.0.4"
+    object.values "^1.1.3"
     prop-types "^15.7.2"
-    resolve "^1.13.1"
+    resolve "^2.0.0-next.3"
+    string.prototype.matchall "^4.0.4"
 
 eslint-scope@^5.0.0:
   version "5.0.0"
@@ -1290,6 +1314,15 @@ get-func-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
@@ -1391,6 +1424,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
@@ -1401,12 +1439,12 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
-  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
-has@^1.0.1, has@^1.0.3:
+has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -1553,6 +1591,15 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
@@ -1583,15 +1630,27 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-bigint@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.1.tgz#6923051dfcbc764278540b9ce0e6b3213aa5ebc2"
+  integrity sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
+
+is-boolean-object@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0"
+  integrity sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-buffer@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
-  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+is-callable@^1.1.4, is-callable@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
 is-ci@2.0.0:
   version "2.0.0"
@@ -1600,10 +1659,17 @@ is-ci@2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-core-module@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
+
 is-date-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
-  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-decimal@^1.0.0:
   version "1.0.3"
@@ -1642,6 +1708,16 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
   integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
 
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-number-object@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
+  integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
+
 is-plain-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.0.0.tgz#7fd1a7f1b69e160cde9181d2313f445c68aa2679"
@@ -1652,14 +1728,20 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+is-regex@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
+  integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
   dependencies:
-    has "^1.0.1"
+    call-bind "^1.0.2"
+    has-symbols "^1.0.1"
 
-is-symbol@^1.0.2:
+is-string@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
+  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
+is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
@@ -1753,13 +1835,21 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsx-ast-utils@^2.0.1, jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
+jsx-ast-utils@^2.0.1, jsx-ast-utils@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
   integrity sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==
   dependencies:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
+
+"jsx-ast-utils@^2.4.1 || ^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz#41108d2cec408c3453c1bbe8a4aae9e1e2bd8f82"
+  integrity sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==
+  dependencies:
+    array-includes "^3.1.2"
+    object.assign "^4.1.2"
 
 leven@3.1.0:
   version "3.1.0"
@@ -2030,54 +2120,54 @@ object-assign@^4.0.1, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-inspect@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
-  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
+object-inspect@^1.9.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.2.tgz#b6385a3e2b7cae0b5eafcf90cddf85d128767f30"
+  integrity sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==
 
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+object.assign@^4.1.0, object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
-
-object.entries@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
-  integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
-  dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.12.0"
-    function-bind "^1.1.1"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.entries@^1.1.0, object.entries@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.3.tgz#c601c7f168b62374541a07ddbd3e2d5e4f7711a6"
+  integrity sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
-object.fromentries@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.1.tgz#050f077855c7af8ae6649f45c80b16ee2d31e704"
-  integrity sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==
+object.fromentries@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.4.tgz#26e1ba5c4571c5c6f0890cef4473066456a120b8"
+  integrity sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==
   dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.15.0"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.2"
     has "^1.0.3"
 
-object.values@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
-  integrity sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==
+object.values@^1.1.0, object.values@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.3.tgz#eaa8b1e17589f02f698db093f7c62ee1699742ee"
+  integrity sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==
   dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.12.0"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.2"
     has "^1.0.3"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
@@ -2503,9 +2593,9 @@ randomfill@^1.0.3:
     safe-buffer "^5.1.0"
 
 react-is@^16.8.1:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
-  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -2553,6 +2643,14 @@ regexp-util@1.2.2, regexp-util@^1.2.0, regexp-util@^1.2.1:
   integrity sha512-5/rl2UD18oAlLQEIuKBeiSIOp1hb5wCXcakl5yvHxlY1wyWI4D5cUKKzCibBeu741PA9JKvZhMqbkDQqPusX3w==
   dependencies:
     tslib "^1.9.0"
+
+regexp.prototype.flags@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -2607,11 +2705,27 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@1.13.1, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.5.0:
+resolve@1.13.1, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.5.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
   integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
   dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.13.1:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
+resolve@^2.0.0-next.3:
+  version "2.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.3.tgz#d41016293d4a8586a39ca5d9b5f15cbea1f55e46"
+  integrity sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==
+  dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
@@ -2700,6 +2814,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 sigmund@^1.0.1:
   version "1.0.1"
@@ -2817,21 +2940,34 @@ string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.trimleft@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
-  integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
+string.prototype.matchall@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz#608f255e93e072107f5de066f81a2dfb78cf6b29"
+  integrity sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==
   dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.2"
+    has-symbols "^1.0.1"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.3.1"
+    side-channel "^1.0.4"
 
-string.prototype.trimright@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
-  integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
   dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    function-bind "^1.1.1"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 string_decoder@^1.0.0:
   version "1.3.0"
@@ -3022,6 +3158,16 @@ uglify-js@^3.1.4:
     commander "~2.20.3"
     source-map "~0.6.1"
 
+unbox-primitive@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
 unherit@^1.0.4:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.2.tgz#14f1f397253ee4ec95cec167762e77df83678449"
@@ -3177,6 +3323,17 @@ vnopts@1.0.2:
     chalk "^2.4.1"
     leven "^2.1.0"
     tslib "^1.9.3"
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
In this PR:
- Per #51, `jsx-no-target-blank` from newer versions of `eslint-plugin-react` crashes when running against Coffeescript code. So (a) upgrade `eslint-plugin-react` to the newest version (b) override `jsx-no-target-blank` (c) fix that version of `eslint-plugin-react` (I think this is a better approach than specifying a range of allowed versions which could encourage breakage like this)