### PR TITLE
Add repo metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,13 @@
     "eslint-visitor-keys": "^1.0.0",
     "jsx-ast-utils": "^2.0.1",
     "lodash": "^4.17.10"
+  },
+  "homepage": "https://github.com/helixbass/eslint-plugin-coffee",
+  "bugs": {
+    "url": "https://github.com/helixbass/eslint-plugin-coffee/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/helixbass/eslint-plugin-coffee"
   }
 }


### PR DESCRIPTION
In this PR:
- per [this comment](https://github.com/helixbass/eslint-plugin-coffee/issues/69#issuecomment-912899984), add `homepage`/`repository` info to `package.json`