### PR TITLE
Fix issue with dev versions + NPM 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node_modules/mocha/bin/_mocha lib/tests/**/*.js",
     "watch": "coffee -o lib/ -wc src/",
     "build": "coffee -o lib/ -c src/",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint 'src/**/*.coffee'",
     "lint-fix": "eslint --fix src/*.coffee src/*/*.coffee src/*/*/*.coffee",
     "lint-js": "eslint src/*.coffee src/*/*.coffee -c .eslintrc-js.yml"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-coffee",
-  "version": "0.1.15",
+  "version": "0.1.16-dev.1",
   "description": "ESLint plugin for Coffeescript",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-coffee",
-  "version": "0.1.16-dev.1",
+  "version": "0.1.16-dev.2",
   "description": "ESLint plugin for Coffeescript",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #69 

In this PR:
- avoid issue where as of NPM 7 `gitpkg`-created dev versions weren't able to be installed correctly by using `prepublishOnly` hook instead of `prepublish`

To test:
I tested this by seeing NPM 7+ (specifically NPM 8.1.1) fail as described in #69 in a new dummy Node project when trying to run `npm install --save-dev github:helixbass/eslint-plugin-coffee#eslint-plugin-coffee-v0.1.15-dev.8-gitpkg` and then seeing it work to run `npm install --save-dev github:helixbass/eslint-plugin-coffee#eslint-plugin-coffee-v0.1.16-dev.1-gitpkg` (which was generated from this branch so uses `prepublishOnly`)